### PR TITLE
Add hybrid OCR pipeline for invoice and statement ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Une application locale simple pour:
 
-- Lire des factures PDF et en extraire les champs clés
+- Lire des factures PDF **ou images** (PNG/JPG/TIFF) et en extraire les champs clés
 - Convertir en XML (si vous vouliez « xql », merci de confirmer; ici on exporte en XML)
-- Charger un relevé bancaire (PDF/CSV/XLSX)
+- Charger un relevé bancaire (PDF/CSV/XLSX ou image scannée)
 - Faire le matching facture ↔ opération bancaire
 - Exporter les résultats (CSV) et les factures extraites (XML)
 
@@ -77,8 +77,8 @@ Notes Cloud:
 
 ## Utilisation
 
-1. Chargez une ou plusieurs factures PDF.
-2. Chargez le relevé bancaire (PDF/CSV/XLSX). Le mapping de colonnes est détecté automatiquement (date, description, montant).
+1. Chargez une ou plusieurs factures (PDF ou images scannées).
+2. Chargez le relevé bancaire (PDF/CSV/XLSX ou photo). Le mapping de colonnes est détecté automatiquement (date, description, montant).
 3. Cliquez sur « Extraire factures » puis « Charger relevé ».
 4. Si souhaité, activez « Utiliser LLM local (Ollama) » dans la barre latérale (serveur Ollama nécessaire, modèle par défaut: `gpt-oss:20b`).
 5. Téléchargez l’export XML des factures et le CSV des résultats de matching.
@@ -92,8 +92,8 @@ Notes Cloud:
 ## Détails techniques
 
 - UI: `Streamlit` avec un style léger (voir `app/assets/styles.css`).
-- Extraction PDF: `pdfplumber` + heuristiques (numéro de facture, date, total, devise) puis enrichissement optionnel par LLM.
-- Relevé bancaire: PDF/CSV/XLSX. Pour PDF, extraction par tables puis fallback texte.
+- Extraction documents: `PyMuPDF` pour le texte natif + OCR hybride (`PaddleOCR` multi-langue puis `pytesseract` en secours) afin de lire les scans et photos. Les heuristiques (numéro de facture, date, total, devise) restent identiques avec enrichissement optionnel par LLM.
+- Relevé bancaire: PDF/CSV/XLSX/Images. Pour PDF, extraction par tables puis fallback texte/OCR partagé avec les factures.
 - Matching: tolérance de montant configurable (par défaut 0.02 EUR) et fenêtre de temps (90 jours). Vérifie aussi la présence du numéro de facture dans la description via fuzzy matching.
 - Export: XML des factures; CSV des correspondances.
 

--- a/app/main.py
+++ b/app/main.py
@@ -73,16 +73,17 @@ def _display_sidebar() -> Dict[str, Any]:
 
 def _display_file_uploaders() -> Dict[str, Any]:
     """Displays file uploaders and returns a dictionary of uploaded files."""
-    st.subheader("1) Charger les factures PDF")
+    st.subheader("1) Charger les factures (PDF ou images)")
     pdf_files = st.file_uploader(
-        "Sélectionnez une ou plusieurs factures (PDF)",
-        type=["pdf"],
+        "Sélectionnez une ou plusieurs factures (PDF, PNG, JPG...)",
+        type=["pdf", "png", "jpg", "jpeg", "tiff", "tif", "bmp", "webp"],
         accept_multiple_files=True,
     )
 
-    st.subheader("2) Charger le relevé bancaire (PDF/CSV/XLSX)")
+    st.subheader("2) Charger le relevé bancaire (PDF/CSV/XLSX ou image)")
     bank_file = st.file_uploader(
-        "Sélectionnez le relevé bancaire", type=["pdf", "csv", "xlsx", "xls"]
+        "Sélectionnez le relevé bancaire",
+        type=["pdf", "csv", "xlsx", "xls", "png", "jpg", "jpeg", "tiff", "tif"],
     )
     return {"pdf_files": pdf_files, "bank_file": bank_file}
 
@@ -93,7 +94,7 @@ def _handle_extraction(
     """Handles the invoice extraction process."""
     if st.button("🚀 Extraire factures"):
         if not pdf_files:
-            st.warning("Veuillez charger au moins une facture PDF.")
+            st.warning("Veuillez charger au moins une facture (PDF ou image).")
             return None
         with st.spinner("Extraction en cours..."):
             extracted_invoices = extract_invoices_from_pdfs(

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,8 @@ python-dateutil==2.9.0.post0
 rapidfuzz==3.9.1
 openpyxl==3.1.5
 requests==2.32.3
+numpy==1.26.4
+PyMuPDF==1.24.9
+Pillow==10.4.0
+paddleocr==2.7.3
+pytesseract==0.3.10

--- a/src/bank_matching.py
+++ b/src/bank_matching.py
@@ -11,12 +11,29 @@ import pdfplumber
 from dateutil import parser as dateparser
 from rapidfuzz import fuzz
 
+from .ocr import SUPPORTED_IMAGE_FORMATS, extract_text_from_any
+
 
 def _read_statement_to_dataframe(file) -> pd.DataFrame:
     """Reads a bank statement file (CSV or Excel) into a DataFrame."""
     name = getattr(file, "name", "releve")
     if name.lower().endswith(".pdf"):
         return _read_bank_pdf_to_dataframe(file)
+    if any(name.lower().endswith(ext) for ext in SUPPORTED_IMAGE_FORMATS):
+        content = file.read()
+        text = extract_text_from_any(content, name)
+        try:
+            file.seek(0)
+        except Exception:
+            pass
+        df = _build_df_from_text_lines(
+            [ln.strip() for ln in text.splitlines() if ln.strip()]
+        )
+        if df is not None:
+            return df
+        raise ValueError(
+            "Impossible de détecter des transactions dans l'image fournie."
+        )
     if name.lower().endswith((".xlsx", ".xls")):
         return pd.read_excel(file)
 
@@ -136,6 +153,32 @@ def _build_df_from_table(table: List[List[str]]) -> Optional[pd.DataFrame]:
     return out
 
 
+def _build_df_from_text_lines(lines: List[str]) -> Optional[pd.DataFrame]:
+    recs: List[Dict[str, Any]] = []
+    date_re = re.compile(r"^(\d{1,2}[\-/]\d{1,2}[\-/]\d{2,4})\s+(.*)")
+    amt_re = re.compile(r"([+-]?\s*\d[\d\s\.,]*)$")
+    from .utils import parse_date as _parse_date, parse_amount as _parse_amount
+
+    for ln in lines:
+        m = date_re.match(ln)
+        if not m:
+            continue
+        d_s, rest = m.groups()
+        amt_m = amt_re.search(rest)
+        if not amt_m:
+            continue
+        amt_s = amt_m.group(1)
+        desc = rest[: amt_m.start(1)].strip()
+        dt = _parse_date(d_s)
+        amt = _parse_amount(amt_s)
+        if dt and amt is not None:
+            recs.append({"date": dt, "description": desc, "amount": amt})
+
+    if recs:
+        return pd.DataFrame(recs)
+    return None
+
+
 def _read_bank_pdf_to_dataframe(file) -> pd.DataFrame:
     """Extracts transactions from a PDF bank statement.
 
@@ -187,8 +230,20 @@ def _read_bank_pdf_to_dataframe(file) -> pd.DataFrame:
                             "description": desc,
                             "amount": amt,
                         })
-                if recs:
-                    frames.append(pd.DataFrame(recs))
+                df_text = _build_df_from_text_lines(lines)
+                if df_text is not None:
+                    frames.append(df_text)
+
+    if not frames:
+        fallback_text = extract_text_from_any(
+            content, getattr(file, "name", "releve.pdf")
+        )
+        if fallback_text:
+            df_text = _build_df_from_text_lines(
+                [ln.strip() for ln in fallback_text.splitlines() if ln.strip()]
+            )
+            if df_text is not None:
+                frames.append(df_text)
 
     if not frames:
         raise ValueError("Aucune transaction détectée dans le PDF du relevé.")

--- a/src/invoice_extraction.py
+++ b/src/invoice_extraction.py
@@ -1,11 +1,9 @@
-import io
 import re
 from typing import Any, Dict, List, Optional
 
-import pdfplumber
-
 from .llm_extraction import extract_with_llm
 from .utils import parse_amount, parse_date, safe_lower
+from .ocr import extract_text_from_any
 
 INVOICE_NUMBER_PATTERNS = [
     r"facture\s*(?:n[°o]|no|num(?:éro)?)\s*[:#-]?\s*([A-Za-z0-9\-_/]{3,})",
@@ -23,15 +21,6 @@ TOTAL_PATTERNS = [
 ]
 
 CURRENCY_MARKERS = ["eur", "€", "eur.", "euro", "euros"]
-
-
-def extract_text_from_pdf(file_bytes: bytes) -> str:
-    with pdfplumber.open(io.BytesIO(file_bytes)) as pdf:
-        texts = []
-        for page in pdf.pages:
-            txt = page.extract_text(x_tolerance=2, y_tolerance=2) or ""
-            texts.append(txt)
-    return "\n".join(texts)
 
 
 def _find_invoice_number(low_text: str) -> Optional[str]:
@@ -108,7 +97,12 @@ def extract_invoices_from_pdfs(
     results: List[Dict[str, Any]] = []
     for f in files:
         content = f.read()
-        text = extract_text_from_pdf(content)
+        filename = getattr(f, "name", "facture.pdf")
+        text = extract_text_from_any(content, filename)
+        try:
+            f.seek(0)
+        except Exception:
+            pass
 
         parsed = heuristic_parse(text)
         if use_llm:

--- a/src/ocr.py
+++ b/src/ocr.py
@@ -1,0 +1,145 @@
+"""High quality OCR utilities used for invoice and statement extraction."""
+
+from __future__ import annotations
+
+import io
+from functools import lru_cache
+from typing import Iterable, List, Optional
+
+import fitz  # type: ignore[import]
+import numpy as np
+from PIL import Image
+
+try:  # pragma: no cover - optional dependency heavy to import in tests
+    from paddleocr import PaddleOCR  # type: ignore
+except Exception:  # pragma: no cover - paddleocr is optional at runtime
+    PaddleOCR = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
+    import pytesseract
+    from pytesseract import TesseractNotFoundError
+except Exception:  # pragma: no cover - optional dependency
+    pytesseract = None  # type: ignore[assignment]
+    TesseractNotFoundError = RuntimeError  # type: ignore[assignment]
+
+
+SUPPORTED_IMAGE_FORMATS = {".png", ".jpg", ".jpeg", ".tif", ".tiff", ".bmp", ".webp"}
+
+
+def _pixmap_to_image(pix: "fitz.Pixmap") -> Image.Image:
+    """Converts a PyMuPDF pixmap to a PIL image."""
+
+    mode = "RGB"
+    if pix.alpha:  # remove alpha channel for better OCR stability
+        pix = fitz.Pixmap(pix, 0)  # type: ignore[arg-type]
+    if pix.colorspace and pix.colorspace.n == 1:
+        mode = "L"
+    return Image.frombytes(mode, [pix.width, pix.height], pix.samples)
+
+
+@lru_cache(maxsize=1)
+def _get_paddle_ocr() -> Optional["PaddleOCR"]:
+    """Returns a cached PaddleOCR instance if the library is available."""
+
+    if PaddleOCR is None:  # pragma: no cover - optional dependency
+        return None
+    try:
+        return PaddleOCR(lang="fr", use_angle_cls=True, show_log=False)
+    except Exception:  # pragma: no cover - Paddle may fail to initialise
+        return None
+
+
+def _ocr_with_paddle(image: Image.Image) -> Optional[str]:
+    ocr = _get_paddle_ocr()
+    if ocr is None:
+        return None
+    arr = np.array(image)
+    result = ocr.ocr(arr, cls=True)
+    lines: List[str] = []
+    for page in result or []:
+        for line in page:
+            if line and len(line) >= 2:
+                text = line[1][0]
+                if text:
+                    lines.append(text)
+    return "\n".join(lines) if lines else None
+
+
+def _ocr_with_tesseract(image: Image.Image) -> Optional[str]:
+    if pytesseract is None:  # pragma: no cover - optional dependency
+        return None
+    try:
+        return pytesseract.image_to_string(image, lang="fra+eng")
+    except TesseractNotFoundError:  # pragma: no cover - depends on host setup
+        return None
+
+
+def ocr_image(data: bytes) -> str:
+    """Runs OCR on an image binary payload."""
+
+    with Image.open(io.BytesIO(data)) as img:
+        img = img.convert("RGB")
+        return ocr_image_from_pil(img)
+
+
+def extract_text_from_pdf(data: bytes, zoom: float = 2.0) -> str:
+    """Extracts text from a PDF using native text extraction + OCR fallback."""
+
+    texts: List[str] = []
+
+    with fitz.open(stream=data, filetype="pdf") as doc:
+        for page in doc:
+            # Start with the embedded text when available
+            raw_text = page.get_text("text") or ""
+            cleaned = raw_text.strip()
+            if cleaned:
+                texts.append(cleaned)
+                # If the native text is rich enough, skip OCR to save time
+                if len(cleaned.split()) > 10:
+                    continue
+
+            # If the page is scanned (no embedded text) or text is too light, render at high resolution
+            matrix = fitz.Matrix(zoom, zoom)
+            pix = page.get_pixmap(matrix=matrix, alpha=False)
+            image = _pixmap_to_image(pix)
+            text = ocr_image_from_pil(image)
+            if text:
+                texts.append(text)
+
+    return "\n".join(texts)
+
+
+def ocr_image_from_pil(image: Image.Image) -> str:
+    """Runs OCR on a PIL image instance."""
+
+    if image.mode not in ("RGB", "L"):
+        image = image.convert("RGB")
+    text = _ocr_with_paddle(image)
+    if text:
+        return text
+    text = _ocr_with_tesseract(image)
+    if text:
+        return text
+    return ""
+
+
+def extract_text_from_any(data: bytes, filename: str) -> str:
+    """Extracts text from any supported document type."""
+
+    lower = filename.lower()
+    if lower.endswith(".pdf") or lower.endswith(".xps"):
+        return extract_text_from_pdf(data)
+    if any(lower.endswith(ext) for ext in SUPPORTED_IMAGE_FORMATS):
+        return ocr_image(data)
+    # Fallback: try to open as PDF anyway
+    try:
+        return extract_text_from_pdf(data)
+    except Exception:
+        return ""
+
+
+def extract_text_from_multiple(files: Iterable[bytes], names: Iterable[str]) -> List[str]:
+    """Convenience function to OCR multiple payloads."""
+
+    return [extract_text_from_any(data, name) for data, name in zip(files, names)]
+

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from dateutil import parser as dateparser
 
-AMOUNT_RE = re.compile(r"([+-]?)\s*(\d{1,3}(?:[\.,]\d{3})*|\d+)([\.,](\d{2}))?")
+AMOUNT_RE = re.compile(r"([+-]?)\s*(\d{1,3}(?:[\.,]\d{3})+|\d+)([\.,](\d{2}))?")
 
 
 def parse_date(text: str) -> Optional[datetime]:


### PR DESCRIPTION
## Summary
- introduce a shared OCR module powered by PyMuPDF with PaddleOCR/Tesseract fallbacks for scanned PDFs and images
- enable image uploads for invoices and bank statements while reusing OCR during bank parsing
- refresh documentation, dependencies, and amount parsing to reflect the broader document support

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_b_68dc00142560832395939f30a0c0f469